### PR TITLE
fix: use same bit-shift as engine for cloth charges in JSON extract

### DIFF
--- a/Utils/convertDungeonDatToJson/Program.cs
+++ b/Utils/convertDungeonDatToJson/Program.cs
@@ -421,7 +421,7 @@ namespace convertDungeonDatToJson {
                         d.objs.Add(newObj = new ClothDef {
                             itemType = (attr >> 0) & 127,
                             important = 0 != ((attr >> 7) & 1),
-                            charges = (attr >> 10) & 15,
+                            charges = (attr >> 9) & 15,
                         });
                         break;
                     }


### PR DESCRIPTION
I found a small discrepancy in the way cloth charges are handled. The engine seems to bit-shift by 9 whereas the extract use 10. It seems this logic was imported from the weapon charges located just above, that do use 10.